### PR TITLE
Address edge case of project_name:null and a custom library_title

### DIFF
--- a/_template/index.html
+++ b/_template/index.html
@@ -4,7 +4,7 @@
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width">
 
-        <title v-text="project_name ? project_name + ' | ' + (theme.titles.library_title ? theme.titles.library_title : 'Pattern Library') : 'Pattern Library'"></title>
+        <title v-text="project_name ? project_name + ' | ' + theme.titles.library_title : theme.titles.library_title"></title>
 
         <!-- Astrum (https://github.com/NoDivide/astrum) -->
         <meta name="application-name" content="Astrum {{ version }}" />


### PR DESCRIPTION
#### What does this PR cover?
As mentioned in https://github.com/NoDivide/astrum/pull/148#pullrequestreview-78988017

I removed the hard coded 'Pattern Library' fallback since it's the default anyways when initializing a project.

#### How can this be tested?
Set the `project_name` property in `data.json` to `null` and define a custom `library_title`

#### Screenshots / Screencast
<img width="1276" alt="screen shot 2017-11-24 at 23 42 26" src="https://user-images.githubusercontent.com/1641979/33225066-3af25808-d171-11e7-8d6b-9ac5c7fc5d14.png">


